### PR TITLE
POSIX: Do NOT use echo -n

### DIFF
--- a/UTL/parsrj.sh
+++ b/UTL/parsrj.sh
@@ -73,7 +73,7 @@ case $# in [!0]*)
     elif [ \( "_${arg#-ls}" != "_$arg" \) -a \( -z "$file" \) ]; then
       ls=${arg#-ls}
     elif [ \( "_${arg#-fn}" != "_$arg" \) -a \( -z "$file" \) -a \
-           -n "$(echo -n "_${arg#-fn}" | grep '^_[0-9]\{1,\}$')" ]; then
+           -n "$(printf '%s' "_${arg#-fn}" | grep '^_[0-9]\{1,\}$')" ]; then
       fn=${arg#-fn}
       fn=$((fn+0))
     elif [ \( "_$arg" = '_-li' \) -a \( -z "$file" \) ]; then


### PR DESCRIPTION
echo -n is not portable. See the following page for details.

  * http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html

そもそも `echo -n` にしている意図がわからないのですが、もしかして `-n` を削除するだけで充分でしょうか? コマンド展開で実行されたコマンド出力は最後の改行が削除されるので。