### PR TITLE
POSIX: [^<char-class>] is not portable for glob patterns

### DIFF
--- a/BIN/twmediup.sh
+++ b/BIN/twmediup.sh
@@ -101,7 +101,7 @@ while :; do
 done
 
 # === ファイル読取 ===================================================
-case $# in [^1]) print_usage_and_exit;; esac # APIは同時1個しか対応してない
+case $# in [!1]) print_usage_and_exit;; esac # APIは同時1個しか対応してない
 for arg in "$@"; do
   ext=$(printf '%s' "${arg##*/}" | tr -d '\n')
   case "${ext##*.}" in

--- a/BIN/twvideoup.sh
+++ b/BIN/twvideoup.sh
@@ -103,7 +103,7 @@ while :; do
 done
 
 # === オプション読取 =================================================
-case $# in [^1]) print_usage_and_exit;; esac # APIは同時1個しか対応してない
+case $# in [!1]) print_usage_and_exit;; esac # APIは同時1個しか対応してない
 for arg in "$@"; do
   ext=$(printf '%s' "${arg##*/}" | tr -d '\n')
   case "${ext##*.}" in


### PR DESCRIPTION
Use [!<char-class>] style instead. See the following page for details.

  * http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13_01