### PR TITLE
UTL/base64: Fixed a bug about macOS bundled base64 command.

### DIFF
--- a/UTL/base64
+++ b/UTL/base64
@@ -241,7 +241,7 @@ case "$by_myself${CMD_BASE64_MAC:-}" in 0/*)
   opts=''
   case $mode in d) opts="$opts -d";; esac
   opts="$opts -b $width"
-  exec "$CMD_BASE64_MAC" $opts -i ${file:--}
+  exec "$CMD_BASE64_MAC" $opts -i "${file:--}"
   exit 1
   ;;
 esac

--- a/UTL/base64
+++ b/UTL/base64
@@ -241,7 +241,7 @@ case "$by_myself${CMD_BASE64_MAC:-}" in 0/*)
   opts=''
   case $mode in d) opts="$opts -d";; esac
   opts="$opts -b $width"
-  exec "$CMD_BASE64_MAC" $opts -i ${file:+"$file"}
+  exec "$CMD_BASE64_MAC" $opts -i ${file:--}
   exit 1
   ;;
 esac


### PR DESCRIPTION
macOS付属のbase64コマンドは、標準入力を受けるのにファイル名引数を与える必要がありました。

~~~
$ echo foo | ./UTL/base64 -w 0
base64: option requires an argument -- i
Usage:	/usr/bin/base64 [-hvD] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  -D, --decode   decodes input
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
~~~

この問題に起因して、`getbtwid.sh`でエラーとなります。